### PR TITLE
Implement shared contexts

### DIFF
--- a/lib/pallets.rb
+++ b/lib/pallets.rb
@@ -3,6 +3,7 @@ require "pallets/version"
 require 'pallets/backends/base'
 require 'pallets/backends/redis'
 require 'pallets/configuration'
+require 'pallets/context'
 require 'pallets/dsl/workflow'
 require 'pallets/errors'
 require 'pallets/graph'

--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -6,12 +6,12 @@ module Pallets
         raise NotImplementedError
       end
 
-      def get_context_log(workflow_id)
+      def get_context(workflow_id)
         raise NotImplementedError
       end
 
       # Saves a job after successfully processing it
-      def save(workflow_id, job, context_log_item)
+      def save(workflow_id, job, context_buffer)
         raise NotImplementedError
       end
 
@@ -34,7 +34,7 @@ module Pallets
         raise NotImplementedError
       end
 
-      def run_workflow(workflow_id, jobs_with_dependencies, initial_context_log, number_of_jobs)
+      def run_workflow(workflow_id, jobs_with_dependencies, context)
         raise NotImplementedError
       end
     end

--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -6,8 +6,12 @@ module Pallets
         raise NotImplementedError
       end
 
+      def get_context_log(workflow_id)
+        raise NotImplementedError
+      end
+
       # Saves a job after successfully processing it
-      def save(workflow_id, job)
+      def save(workflow_id, job, context_log_item)
         raise NotImplementedError
       end
 
@@ -30,7 +34,7 @@ module Pallets
         raise NotImplementedError
       end
 
-      def run_workflow(workflow_id, jobs_with_dependencies)
+      def run_workflow(workflow_id, jobs_with_dependencies, initial_context_log, number_of_jobs)
         raise NotImplementedError
       end
     end

--- a/lib/pallets/backends/redis.rb
+++ b/lib/pallets/backends/redis.rb
@@ -15,6 +15,8 @@ module Pallets
         @retry_set_key = "#{namespace}:retry-set"
         @fail_set_key = "#{namespace}:fail-set"
         @workflow_key = "#{namespace}:workflows:%s"
+        @context_log_key = "#{namespace}:context-logs:%s"
+        @counter_key = "#{namespace}:counters:%s"
 
         register_scripts
       end
@@ -35,12 +37,18 @@ module Pallets
         job
       end
 
-      def save(workflow_id, job)
+      def get_context_log(workflow_id)
+        @pool.execute do |client|
+          client.lrange(@context_log_key % workflow_id, 0, -1)
+        end
+      end
+
+      def save(workflow_id, job, context_log_item)
         @pool.execute do |client|
           client.eval(
             @scripts['save'],
-            [@workflow_key % workflow_id, @queue_key, @reliability_queue_key, @reliability_set_key],
-            [job]
+            [@workflow_key % workflow_id, @queue_key, @reliability_queue_key, @reliability_set_key, @context_log_key % workflow_id, @counter_key % workflow_id],
+            [job, context_log_item]
           )
         end
       end
@@ -85,12 +93,12 @@ module Pallets
         end
       end
 
-      def run_workflow(workflow_id, jobs_with_order)
+      def run_workflow(workflow_id, jobs_with_order, context_log, number_of_jobs)
         @pool.execute do |client|
           client.eval(
             @scripts['run_workflow'],
-            [@workflow_key % workflow_id, @queue_key],
-            jobs_with_order
+            [@workflow_key % workflow_id, @queue_key, @context_log_key % workflow_id, @counter_key % workflow_id],
+            jobs_with_order << context_log << number_of_jobs
           )
         end
       end

--- a/lib/pallets/backends/scripts/run_workflow.lua
+++ b/lib/pallets/backends/scripts/run_workflow.lua
@@ -1,9 +1,8 @@
--- Set counter key
-local number_of_jobs = table.remove(ARGV)
-redis.call("SET", KEYS[4], number_of_jobs)
-
 -- Add all jobs to sorted set
-redis.call("ZADD", KEYS[1], unpack(ARGV))
+local eta = redis.call("ZADD", KEYS[1], unpack(ARGV))
+
+-- Set ETA key; this is merely the number of jobs that need to be processed
+redis.call("SET", KEYS[3], eta)
 
 -- Queue jobs that are ready to be processed (their score is 0) and
 -- remove queued jobs from the sorted set

--- a/lib/pallets/backends/scripts/run_workflow.lua
+++ b/lib/pallets/backends/scripts/run_workflow.lua
@@ -2,10 +2,6 @@
 local number_of_jobs = table.remove(ARGV)
 redis.call("SET", KEYS[4], number_of_jobs)
 
--- Add initial context log item to set
-local context_log = table.remove(ARGV)
-redis.call("RPUSH", KEYS[3], context_log)
-
 -- Add all jobs to sorted set
 redis.call("ZADD", KEYS[1], unpack(ARGV))
 

--- a/lib/pallets/backends/scripts/run_workflow.lua
+++ b/lib/pallets/backends/scripts/run_workflow.lua
@@ -1,3 +1,11 @@
+-- Set counter key
+local number_of_jobs = table.remove(ARGV)
+redis.call("SET", KEYS[4], number_of_jobs)
+
+-- Add initial context log item to set
+local context_log = table.remove(ARGV)
+redis.call("RPUSH", KEYS[3], context_log)
+
 -- Add all jobs to sorted set
 redis.call("ZADD", KEYS[1], unpack(ARGV))
 

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -21,7 +21,8 @@ if count > 0 then
   redis.call("ZREM", KEYS[1], unpack(work))
 end
 
--- Decrement counter and remove it together with the context log if all tasks have been processed (counter is 0)
+-- Decrement ETA and remove it together with the context if all tasks have
+-- been processed (ETA is 0)
 redis.call("DECR", KEYS[6])
 if tonumber(redis.call("GET", KEYS[6])) == 0 then
   redis.call("DEL", KEYS[5], KEYS[6])

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -2,6 +2,9 @@
 redis.call("LREM", KEYS[3], 0, ARGV[1])
 redis.call("ZREM", KEYS[4], ARGV[1])
 
+-- Add context log item to list
+redis.call("RPUSH", KEYS[5], ARGV[2])
+
 -- Decrement all jobs from the sorted set
 local all_pending = redis.call("ZRANGE", KEYS[1], 0, -1)
 for score, task in pairs(all_pending) do
@@ -15,4 +18,10 @@ if count > 0 then
   local work = redis.call("ZRANGEBYSCORE", KEYS[1], 0, 0)
   redis.call("LPUSH", KEYS[2], unpack(work))
   redis.call("ZREM", KEYS[1], unpack(work))
+end
+
+-- Decrement counter and remove it together with the context log if all tasks have been processed (counter is 0)
+redis.call("DECR", KEYS[6])
+if tonumber(redis.call("GET", KEYS[6])) == 0 then
+  redis.call("DEL", KEYS[5], KEYS[6])
 end

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -1,9 +1,10 @@
 -- Remove job from reliability queue
-redis.call("LREM", KEYS[3], 0, ARGV[1])
-redis.call("ZREM", KEYS[4], ARGV[1])
+local job = table.remove(ARGV)
+redis.call("LREM", KEYS[3], 0, job)
+redis.call("ZREM", KEYS[4], job)
 
--- Add context log item to list
-redis.call("RPUSH", KEYS[5], ARGV[2])
+-- Update context hash with buffer
+redis.call("HMSET", KEYS[5], unpack(ARGV))
 
 -- Decrement all jobs from the sorted set
 local all_pending = redis.call("ZRANGE", KEYS[1], 0, -1)

--- a/lib/pallets/context.rb
+++ b/lib/pallets/context.rb
@@ -1,0 +1,13 @@
+module Pallets
+  # Hash-like class that additionally holds a buffer for all write operations
+  class Context < Hash
+    def []=(key, value)
+      buffer[key] = value
+      super
+    end
+
+    def buffer
+      @buffer ||= {}
+    end
+  end
+end

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -10,7 +10,8 @@ module Pallets
     end
 
     def run
-      backend.run_workflow(id, jobs_with_order)
+      context_log_item = serializer.dump(context)
+      backend.run_workflow(id, jobs_with_order, context_log_item, jobs_with_order.size)
       id
     end
 
@@ -25,7 +26,7 @@ module Pallets
     private
 
     def jobs_with_order
-      self.class.graph.sorted_with_order.map do |task_name, order|
+      @jobs_with_order ||= self.class.graph.sorted_with_order.map do |task_name, order|
         job = serializer.dump(job_hash.merge(self.class.task_config[task_name]))
         [order, job]
       end
@@ -34,7 +35,6 @@ module Pallets
     def job_hash
       {
         'workflow_id' => id,
-        'context'     => context,
         'created_at'  => Time.now.to_f
       }
     end

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -10,8 +10,7 @@ module Pallets
     end
 
     def run
-      context_log_item = serializer.dump(context)
-      backend.run_workflow(id, jobs_with_order, context_log_item, jobs_with_order.size)
+      backend.run_workflow(id, jobs_with_order, context)
       id
     end
 
@@ -26,7 +25,7 @@ module Pallets
     private
 
     def jobs_with_order
-      @jobs_with_order ||= self.class.graph.sorted_with_order.map do |task_name, order|
+      self.class.graph.sorted_with_order.map do |task_name, order|
         job = serializer.dump(job_hash.merge(self.class.task_config[task_name]))
         [order, job]
       end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Pallets::Context do
+  it 'is a Hash' do
+    expect(subject).to be_a(Hash)
+  end
+
+  describe '#[]=' do
+    it 'buffers the given value' do
+      subject['foo'] = 'bar'
+      expect(subject.buffer).to match('foo' => 'bar')
+    end
+
+    it 'does not alter the Hash interface' do
+      subject['foo'] = 'bar'
+      expect(subject['foo']).to eq('bar')
+    end
+  end
+
+  describe '#buffer' do
+    context 'when no context has been set' do
+      it 'returns an empty Hash' do
+        expect(subject.buffer).to be_a(Hash).and be_empty
+      end
+    end
+
+    context 'when context has been set' do
+      before do
+        subject['foo'] = 'bar'
+      end
+
+      it 'returns a Hash' do
+        expect(subject.buffer).to match('foo' => 'bar')
+      end
+    end
+  end
+end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -28,13 +28,17 @@ describe Pallets::Workflow do
       allow(subject).to receive(:serializer).and_return(serializer)
     end
 
+    it 'builds a new context log item and uses the serializer to dump it' do
+      subject.run
+      expect(serializer).to have_received(:dump).with(foo: :bar)
+    end
+
     it 'builds a job for each task and uses the serializer to dump it' do
       Timecop.freeze do
         subject.run
         %w(Foo Bar Baz Qux).each do |task_class_name|
           expect(serializer).to have_received(:dump).with({
             'workflow_id' => a_kind_of(String),
-            'context' => { foo: :bar },
             'created_at' => Time.now.to_f,
             'class_name' => task_class_name,
             'max_failures' => 3
@@ -48,7 +52,7 @@ describe Pallets::Workflow do
         subject.run
         expect(backend).to have_received(:run_workflow).with(a_kind_of(String), [
           [0, 'foobar'], [1, 'foobar'], [1, 'foobar'], [3, 'foobar']
-        ])
+        ], 'foobar', 4)
       end
     end
   end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -28,11 +28,6 @@ describe Pallets::Workflow do
       allow(subject).to receive(:serializer).and_return(serializer)
     end
 
-    it 'builds a new context log item and uses the serializer to dump it' do
-      subject.run
-      expect(serializer).to have_received(:dump).with(foo: :bar)
-    end
-
     it 'builds a job for each task and uses the serializer to dump it' do
       Timecop.freeze do
         subject.run
@@ -52,7 +47,7 @@ describe Pallets::Workflow do
         subject.run
         expect(backend).to have_received(:run_workflow).with(a_kind_of(String), [
           [0, 'foobar'], [1, 'foobar'], [1, 'foobar'], [3, 'foobar']
-        ], 'foobar', 4)
+        ], context)
       end
     end
   end


### PR DESCRIPTION
This implements shared contexts for workflows. Every task can now access the context that has been constructed so far¹ and can alter it's contents².

¹ every job gets the latest available context upon processing, meaning that you should not rely on specific context items to be available when processing multiple tasks situated on the same dependency level, at the same time (e.g.: B -> A <- C; B and C can be processed simultaneously; if B adds item X on the context, C may or may not see item X)
² items can be added and updated on the context, but **not removed**

Closes #7.