### PR TITLE
Drop support for Ruby 2.1 and 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,13 @@ language: ruby
 services:
   - redis-server
 cache: bundler
-matrix:
-  # Bundler 2.0 does not support Ruby versions lower than 2.3
-  include:
-  - rvm: 2.1.10
-    before_install: gem install bundler -v '< 2'
-  - rvm: 2.2.10
-    before_install: gem install bundler -v '< 2'
-  - rvm: 2.3.8
-    before_install: gem update --system; gem install bundler
-  - rvm: 2.4.5
-    before_install: gem update --system; gem install bundler
-  - rvm: 2.5.3
-    before_install: gem update --system; gem install bundler
-  - rvm: 2.6.0
-    before_install: gem update --system; gem install bundler
+rvm:
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
+before_install:
+  # Bundler 2.0 needs a newer RubyGems
+  - gem update --system
+  - gem install bundler
 script: bundle exec rspec


### PR DESCRIPTION
They reached end-of-life long ago, so it's better that we stop supporting them.