### PR TITLE
Reduce Redis footprint

### DIFF
--- a/lib/pallets.rb
+++ b/lib/pallets.rb
@@ -34,7 +34,6 @@ module Pallets
     @backend ||= begin
       cls = Pallets::Util.constantize("Pallets::Backends::#{configuration.backend.capitalize}")
       cls.new(
-        namespace: configuration.namespace,
         blocking_timeout: configuration.blocking_timeout,
         failed_job_lifespan: configuration.failed_job_lifespan,
         job_timeout: configuration.job_timeout,

--- a/lib/pallets/backends/redis.rb
+++ b/lib/pallets/backends/redis.rb
@@ -3,21 +3,20 @@ require 'redis'
 module Pallets
   module Backends
     class Redis < Base
-      def initialize(namespace:, blocking_timeout:, failed_job_lifespan:, job_timeout:, pool_size:, **options)
-        @namespace = namespace
+      def initialize(blocking_timeout:, failed_job_lifespan:, job_timeout:, pool_size:, **options)
         @blocking_timeout = blocking_timeout
         @failed_job_lifespan = failed_job_lifespan
         @job_timeout = job_timeout
         @pool = Pallets::Pool.new(pool_size) { ::Redis.new(options) }
 
-        @queue_key = "#{namespace}:queue"
-        @reliability_queue_key = "#{namespace}:reliability-queue"
-        @reliability_set_key = "#{namespace}:reliability-set"
-        @retry_set_key = "#{namespace}:retry-set"
-        @given_up_set_key = "#{namespace}:given-up-set"
-        @workflow_key = "#{namespace}:workflows:%s"
-        @context_key = "#{namespace}:contexts:%s"
-        @eta_key = "#{namespace}:etas:%s"
+        @queue_key = "queue"
+        @reliability_queue_key = "reliability-queue"
+        @reliability_set_key = "reliability-set"
+        @retry_set_key = "retry-set"
+        @given_up_set_key = "given-up-set"
+        @workflow_key = "workflows:%s"
+        @context_key = "contexts:%s"
+        @eta_key = "etas:%s"
 
         register_scripts
       end

--- a/lib/pallets/cli.rb
+++ b/lib/pallets/cli.rb
@@ -65,10 +65,6 @@ module Pallets
           Pallets.configuration.failed_job_lifespan = failed_job_lifespan
         end
 
-        opts.on('-n', '--namespace NAME', 'Namespace to use for backend') do |namespace|
-          Pallets.configuration.namespace = namespace
-        end
-
         opts.on('-p', '--pool-size NUM', Integer, 'Size of backend pool') do |pool_size|
           Pallets.configuration.pool_size = pool_size
         end

--- a/lib/pallets/configuration.rb
+++ b/lib/pallets/configuration.rb
@@ -24,9 +24,6 @@ module Pallets
     # per task basis
     attr_accessor :max_failures
 
-    # Namespace used by the backend to store information
-    attr_accessor :namespace
-
     # Number of connections to the backend
     attr_accessor :pool_size
 
@@ -41,7 +38,6 @@ module Pallets
       @failed_job_lifespan = 7_776_000 # 3 months
       @job_timeout = 1_800 # 30 minutes
       @max_failures = 3
-      @namespace = 'pallets'
       @pool_size = 5
       @serializer = :json
     end

--- a/lib/pallets/dsl/workflow.rb
+++ b/lib/pallets/dsl/workflow.rb
@@ -11,12 +11,12 @@ module Pallets
           [arg, depends_on]
         end
 
-        class_name = klass.to_s
+        task_class = klass.to_s
         dependencies = Array(dependencies).compact.uniq.map(&:to_s)
-        graph.add(class_name, dependencies)
+        graph.add(task_class, dependencies)
 
-        task_config[class_name] = {
-          'class_name' => class_name,
+        task_config[task_class] = {
+          'task_class' => task_class,
           'max_failures' => max_failures || Pallets.configuration.max_failures
         }
 

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -128,7 +128,6 @@ module Pallets
       {
         wid:  id,
         wfid: job_hash['wfid'],
-        jid:  job_hash['jid'],
         wf:   job_hash['workflow_class'],
         tsk:  job_hash['task_class']
       }

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -72,10 +72,10 @@ module Pallets
       Pallets.logger.info "Started", extract_metadata(job_hash)
 
       context = Context[
-        serializer.load_context(backend.get_context(job_hash['workflow_id']))
+        serializer.load_context(backend.get_context(job_hash['wfid']))
       ]
 
-      task_class = Pallets::Util.constantize(job_hash["class_name"])
+      task_class = Pallets::Util.constantize(job_hash["task_class"])
       task = task_class.new(context)
       begin
         task_result = task.run
@@ -120,16 +120,17 @@ module Pallets
     end
 
     def handle_job_success(context, job, job_hash)
-      backend.save(job_hash['workflow_id'], job, serializer.dump_context(context.buffer))
+      backend.save(job_hash['wfid'], job, serializer.dump_context(context.buffer))
       Pallets.logger.info "Done", extract_metadata(job_hash)
     end
 
     def extract_metadata(job_hash)
       {
         wid:  id,
-        wfid: job_hash['workflow_id'],
-        wf:   job_hash['workflow_class_name'],
-        tsk:  job_hash['class_name']
+        wfid: job_hash['wfid'],
+        jid:  job_hash['jid'],
+        wf:   job_hash['workflow_class'],
+        tsk:  job_hash['task_class']
       }
     end
 

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -29,17 +29,17 @@ module Pallets
     private
 
     def jobs_with_order
-      self.class.graph.sorted_with_order.map do |task_name, order|
-        job = serializer.dump(job_hash.merge(self.class.task_config[task_name]))
+      self.class.graph.sorted_with_order.map do |task_class, order|
+        job = serializer.dump(job_hash.merge(self.class.task_config[task_class]))
         [order, job]
       end
     end
 
     def job_hash
       {
-        'workflow_id'         => id,
-        'workflow_class_name' => self.class.name,
-        'created_at'          => Time.now.to_f
+        'wfid'           => id,
+        'workflow_class' => self.class.name,
+        'created_at'     => Time.now.to_f
       }
     end
 

--- a/spec/backends/redis_spec.rb
+++ b/spec/backends/redis_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Pallets::Backends::Redis do
   subject do
     Pallets::Backends::Redis.new(
-      namespace: 'test',
       blocking_timeout: 1,
       failed_job_lifespan: 100,
       job_timeout: 10,
@@ -21,7 +20,7 @@ describe Pallets::Backends::Redis do
   describe '#pick' do
     context 'with work available' do
       before do
-        redis.lpush('test:queue', 'foo')
+        redis.lpush('queue', 'foo')
       end
 
       it 'returns the job' do
@@ -30,13 +29,13 @@ describe Pallets::Backends::Redis do
 
       it 'pushes the job to the reliability queue' do
         subject.pick
-        expect(redis.lrange('test:reliability-queue', 0, -1)).to eq(['foo'])
+        expect(redis.lrange('reliability-queue', 0, -1)).to eq(['foo'])
       end
 
       it 'adds the job to the reliability set' do
         Timecop.freeze do
           subject.pick
-          expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to eq([['foo', Time.now.to_f + 10]])
+          expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to eq([['foo', Time.now.to_f + 10]])
         end
       end
     end
@@ -55,12 +54,12 @@ describe Pallets::Backends::Redis do
 
       it 'does not push anything to the reliability queue' do
         subject.pick
-        expect(redis.lrange('test:reliability-queue', 0, -1)).to be_empty
+        expect(redis.lrange('reliability-queue', 0, -1)).to be_empty
       end
 
       it 'does not add anything to the reliability set' do
         subject.pick
-        expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to be_empty
+        expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to be_empty
       end
     end
   end
@@ -68,7 +67,7 @@ describe Pallets::Backends::Redis do
   describe '#get_context' do
     before do
       # Set up context
-      redis.hmset('test:contexts:baz', ['foo', 'bar', 'baz', 'qux'])
+      redis.hmset('contexts:baz', ['foo', 'bar', 'baz', 'qux'])
     end
 
     it 'retrieves the context' do
@@ -79,76 +78,76 @@ describe Pallets::Backends::Redis do
   describe '#save' do
     before do
       # Set up reliability components
-      redis.lpush('test:reliability-queue', 'foo')
-      redis.zadd('test:reliability-set', 123, 'foo')
+      redis.lpush('reliability-queue', 'foo')
+      redis.zadd('reliability-set', 123, 'foo')
 
       # Set up context
-      redis.hset('test:contexts:baz', 'foo', 'bar')
+      redis.hset('contexts:baz', 'foo', 'bar')
     end
 
     it 'removes the job from the reliability queue' do
       subject.save('baz', 'foo', 'baz' => 'qux')
-      expect(redis.lrange('test:reliability-queue', 0, -1)).to be_empty
+      expect(redis.lrange('reliability-queue', 0, -1)).to be_empty
     end
 
     it 'removes the job from the reliability set' do
       subject.save('baz', 'foo', 'baz' => 'qux')
-      expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to be_empty
+      expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to be_empty
     end
 
     context 'with a non-empty context buffer' do
       it 'adds the context buffer to the context' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.hgetall('test:contexts:baz')).to eq('foo' => 'bar', 'baz' => 'qux')
+        expect(redis.hgetall('contexts:baz')).to eq('foo' => 'bar', 'baz' => 'qux')
       end
     end
 
     context 'with an empty context buffer' do
       it 'does not touch the context' do
         subject.save('baz', 'foo', {})
-        expect(redis.hgetall('test:contexts:baz')).to eq('foo' => 'bar')
+        expect(redis.hgetall('contexts:baz')).to eq('foo' => 'bar')
       end
     end
 
     context 'with more jobs to queue' do
       before do
         # Set up jobs sorted set
-        redis.zadd('test:workflows:baz', [[1, 'bar'], [2, 'baz'], [5, 'qux']])
+        redis.zadd('workflows:baz', [[1, 'bar'], [2, 'baz'], [5, 'qux']])
 
         # Set up ETA
-        redis.set('test:etas:baz', 3)
+        redis.set('etas:baz', 3)
       end
 
       it 'decrements and removes jobs with 0 from workflow set' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.zrange('test:workflows:baz', 0, -1, with_scores: true)).to eq([['baz', 1], ['qux', 4]])
+        expect(redis.zrange('workflows:baz', 0, -1, with_scores: true)).to eq([['baz', 1], ['qux', 4]])
       end
 
       it 'queues jobs that are ready to be processed' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.lrange('test:queue', 0, -1)).to eq(['bar'])
+        expect(redis.lrange('queue', 0, -1)).to eq(['bar'])
       end
 
       it 'decrements the ETA' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.get('test:etas:baz')).to eq('2')
+        expect(redis.get('etas:baz')).to eq('2')
       end
     end
 
     context 'with no more jobs to queue' do
       before do
         # Set up ETA
-        redis.set('test:etas:baz', 1)
+        redis.set('etas:baz', 1)
       end
 
       it 'clears the context' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.exists('test:contexts:baz')).to be(false)
+        expect(redis.exists('contexts:baz')).to be(false)
       end
 
       it 'clears the ETA' do
         subject.save('baz', 'foo', 'baz' => 'qux')
-        expect(redis.exists('test:etas:baz')).to be(false)
+        expect(redis.exists('etas:baz')).to be(false)
       end
     end
   end
@@ -156,24 +155,24 @@ describe Pallets::Backends::Redis do
   describe '#retry' do
     before do
       # Set up reliability components
-      redis.lpush('test:reliability-queue', 'foo')
-      redis.zadd('test:reliability-set', 123, 'foo')
+      redis.lpush('reliability-queue', 'foo')
+      redis.zadd('reliability-set', 123, 'foo')
     end
 
     it 'removes the job from the reliability queue' do
       subject.retry('foonew', 'foo', 1234)
-      expect(redis.lrange('test:reliability-queue', 0, -1)).to be_empty
+      expect(redis.lrange('reliability-queue', 0, -1)).to be_empty
     end
 
     it 'removes the job from the reliability set' do
       subject.retry('foonew', 'foo', 1234)
-      expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to be_empty
+      expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to be_empty
     end
 
     it 'adds the new job to the retry set' do
       Timecop.freeze do
         subject.retry('foonew', 'foo', 1234)
-        expect(redis.zrange('test:retry-set', 0, -1, with_scores: true)).to eq([['foonew', 1234]])
+        expect(redis.zrange('retry-set', 0, -1, with_scores: true)).to eq([['foonew', 1234]])
       end
     end
   end
@@ -181,36 +180,36 @@ describe Pallets::Backends::Redis do
   describe '#give_up' do
     before do
       # Set up reliability components
-      redis.lpush('test:reliability-queue', 'foo')
-      redis.zadd('test:reliability-set', 123, 'foo')
+      redis.lpush('reliability-queue', 'foo')
+      redis.zadd('reliability-set', 123, 'foo')
     end
 
     it 'removes the job from the reliability queue' do
       subject.give_up('foonew', 'foo')
-      expect(redis.lrange('test:reliability-queue', 0, -1)).to be_empty
+      expect(redis.lrange('reliability-queue', 0, -1)).to be_empty
     end
 
     it 'removes the job from the reliability set' do
       subject.give_up('foonew', 'foo')
-      expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to be_empty
+      expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to be_empty
     end
 
     it 'adds the new job to the given up set' do
       Timecop.freeze do
         subject.give_up('foonew', 'foo')
-        expect(redis.zrange('test:given-up-set', 0, -1, with_scores: true)).to eq([['foonew', Time.now.to_f]])
+        expect(redis.zrange('given-up-set', 0, -1, with_scores: true)).to eq([['foonew', Time.now.to_f]])
       end
     end
 
     context 'with a given up job that failed a long time ago' do
       before do
-        redis.zadd('test:given-up-set', 1234, 'bar')
+        redis.zadd('given-up-set', 1234, 'bar')
       end
 
       it 'removes the given up job from the given up set' do
         Timecop.freeze do
           subject.give_up('foonew', 'foo')
-          expect(redis.zrange('test:given-up-set', 0, -1)).not_to include('bar')
+          expect(redis.zrange('given-up-set', 0, -1)).not_to include('bar')
         end
       end
     end
@@ -219,61 +218,61 @@ describe Pallets::Backends::Redis do
   describe '#reschedule_all' do
     before do
       # Set up reliability components
-      redis.lpush('test:reliability-queue', ['foo', 'bar'])
-      redis.zadd('test:reliability-set', [[123, 'foo'], [1000, 'bar']])
+      redis.lpush('reliability-queue', ['foo', 'bar'])
+      redis.zadd('reliability-set', [[123, 'foo'], [1000, 'bar']])
 
       # Set up retry component
-      redis.zadd('test:retry-set', [[123, 'baz'], [1000, 'qux']])
+      redis.zadd('retry-set', [[123, 'baz'], [1000, 'qux']])
     end
 
     it 'queues reliability and retry jobs that are ready to be processed' do
       subject.reschedule_all(500)
-      expect(redis.lrange('test:queue', 0, -1)).to contain_exactly('foo', 'baz')
+      expect(redis.lrange('queue', 0, -1)).to contain_exactly('foo', 'baz')
     end
 
     it 'removes jobs that are ready to be processed from the reliability set' do
       subject.reschedule_all(500)
-      expect(redis.zrange('test:reliability-set', 0, -1, with_scores: true)).to eq([['bar', 1000]])
+      expect(redis.zrange('reliability-set', 0, -1, with_scores: true)).to eq([['bar', 1000]])
     end
 
     it 'removes jobs that are ready to be processed from the reliability queue' do
       subject.reschedule_all(500)
-      expect(redis.lrange('test:reliability-queue', 0, -1)).to eq(['bar'])
+      expect(redis.lrange('reliability-queue', 0, -1)).to eq(['bar'])
     end
 
     it 'removes jobs that are ready to be processed from the retry set' do
       subject.reschedule_all(500)
-      expect(redis.zrange('test:retry-set', 0, -1, with_scores: true)).to eq([['qux', 1000]])
+      expect(redis.zrange('retry-set', 0, -1, with_scores: true)).to eq([['qux', 1000]])
     end
   end
 
   describe '#run_workflow' do
     it 'sets the ETA' do
       subject.run_workflow('baz', [[0, 'foo'], [1, 'bar']], 'foo' => 'bar')
-      expect(redis.get('test:etas:baz')).to eq('2')
+      expect(redis.get('etas:baz')).to eq('2')
     end
 
     it 'adds pending jobs to workflow set' do
       subject.run_workflow('baz', [[0, 'foo'], [1, 'bar']], 'foo' => 'bar')
-      expect(redis.zrange('test:workflows:baz', 0, -1, with_scores: true)).to eq([['bar', 1]])
+      expect(redis.zrange('workflows:baz', 0, -1, with_scores: true)).to eq([['bar', 1]])
     end
 
     it 'queues jobs that are ready to be processed' do
       subject.run_workflow('baz', [[0, 'foo'], [1, 'bar']], 'foo' => 'bar')
-      expect(redis.lrange('test:queue', 0, -1)).to eq(['foo'])
+      expect(redis.lrange('queue', 0, -1)).to eq(['foo'])
     end
 
     context 'with a non-empty context' do
       it 'sets the context' do
         subject.run_workflow('baz', [[0, 'foo'], [1, 'bar']], 'foo' => 'bar')
-        expect(redis.hgetall('test:contexts:baz')).to eq('foo' => 'bar')
+        expect(redis.hgetall('contexts:baz')).to eq('foo' => 'bar')
       end
     end
 
     context 'with an empty context' do
       it 'does not set the context' do
         subject.run_workflow('baz', [[0, 'foo'], [1, 'bar']], {})
-        expect(redis.exists('test:contexts:baz')).to be(false)
+        expect(redis.exists('contexts:baz')).to be(false)
       end
     end
   end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -11,7 +11,6 @@ describe Pallets::CLI do
       concurrency: 2,
       job_timeout: 1800, # 30 minutes
       max_failures: 3,
-      namespace: 'pallets',
       pool_size: 5,
       serializer: :json
     )
@@ -66,17 +65,6 @@ describe Pallets::CLI do
     it 'sets the failed job lifespan' do
       subject
       expect(configuration).to have_received(:failed_job_lifespan=).with(123)
-    end
-  end
-
-  context 'with --namespace provided' do
-    before do
-      stub_const('ARGV', ['--namespace=foo'])
-    end
-
-    it 'sets the given namespace' do
-      subject
-      expect(configuration).to have_received(:namespace=).with('foo')
     end
   end
 

--- a/spec/dsl/workflow_spec.rb
+++ b/spec/dsl/workflow_spec.rb
@@ -102,7 +102,7 @@ describe Pallets::DSL::Workflow do
     it 'configures the task with the class name' do
       subject.class_eval { task 'Pay' }
       expect(subject.task_config).to match(
-        'Pay' => a_hash_including('class_name' => 'Pay')
+        'Pay' => a_hash_including('task_class' => 'Pay')
       )
     end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -173,8 +173,9 @@ describe Pallets::Worker do
     let(:job) { double }
     let(:job_hash) do
       {
-        'workflow_id' => 'qux',
-        'class_name' => 'Foo',
+        'wfid' => 'qux',
+        'jid' => 'quxqux',
+        'task_class' => 'Foo',
       }
     end
     let(:context_class) { class_double('Pallets::Context').as_stubbed_const }
@@ -304,8 +305,9 @@ describe Pallets::Worker do
     let(:job) { double }
     let(:job_hash) do
       {
-        'workflow_id' => 'qux',
-        'class_name' => 'Foo',
+        'wfid' => 'qux',
+        'jid' => 'quxqux',
+        'task_class' => 'Foo',
         'max_failures' => 15
       }
     end
@@ -334,8 +336,9 @@ describe Pallets::Worker do
       let(:job_hash) do
         {
           'context' => { bar: :baz },
-          'workflow_id' => 'qux',
-          'class_name' => 'Foo',
+          'wfid' => 'qux',
+          'jid' => 'quxqux',
+          'task_class' => 'Foo',
           'max_failures' => 15,
           'failures' => 1,
           'given_up_at' => Time.now.to_f,
@@ -372,9 +375,10 @@ describe Pallets::Worker do
     context 'with the number of failures exceeding the threshold' do
       let(:job_hash) do
         {
-          'workflow_id' => 'qux',
           'context' => { bar: :baz },
-          'class_name' => 'Foo',
+          'wfid' => 'qux',
+          'jid' => 'quxqux',
+          'task_class' => 'Foo',
           'max_failures' => 15,
           'failures' => 15,
           'given_up_at' => Time.now.to_f,
@@ -399,8 +403,9 @@ describe Pallets::Worker do
     let(:job) { double }
     let(:job_hash) do
       {
-        'workflow_id' => 'qux',
-        'class_name' => 'Foo',
+        'wfid' => 'qux',
+        'jid' => 'quxqux',
+        'task_class' => 'Foo',
         'max_failures' => 15
       }
     end
@@ -434,7 +439,7 @@ describe Pallets::Worker do
     let(:job) { double }
     let(:job_hash) do
       {
-        'workflow_id' => 'qux'
+        'wfid' => 'qux'
       }
     end
     let(:context) { instance_spy('Pallets::Context', buffer: { foo: :bar }) }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -59,12 +59,12 @@ describe Pallets::Workflow do
     it 'builds a job for each task and uses the serializer to dump it' do
       Timecop.freeze do
         subject.run
-        %w(Foo Bar Baz Qux).each do |task_class_name|
+        %w(Foo Bar Baz Qux).each do |task_class|
           expect(serializer).to have_received(:dump).with({
-            'workflow_id' => a_kind_of(String),
-            'workflow_class_name' => 'TestWorkflow',
+            'wfid' => a_kind_of(String),
+            'workflow_class' => 'TestWorkflow',
             'created_at' => Time.now.to_f,
-            'class_name' => task_class_name,
+            'task_class' => task_class,
             'max_failures' => 3
           })
         end


### PR DESCRIPTION
Cut off key names, namespaces and other pseudo-useful but overhead-producing stuff:
* namespaces: better off using a dedicated db;
* shorten certain keys
* shorten certain job attributes