### PR TITLE
Cleanup related keys when given up jobs are cleaned up

### DIFF
--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -21,7 +21,7 @@ module Pallets
       end
 
       # Gives up job after repeteadly failing to process it
-      def give_up(job, old_job)
+      def give_up(job, old_job, workflow_id = nil)
         raise NotImplementedError
       end
 

--- a/lib/pallets/backends/scripts/give_up.lua
+++ b/lib/pallets/backends/scripts/give_up.lua
@@ -2,8 +2,15 @@
 redis.call("LREM", KEYS[2], 0, ARGV[3])
 redis.call("ZREM", KEYS[3], ARGV[3])
 
--- Add job and its fail time (score) to failed sorted set
+-- Add job and its cleanup time (score) to failed sorted set
 redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+
+-- Schedule cleanup for related keys (workflow queue, context and ETA), if given
+if KEYS[4] and KEYS[5] and KEYS[6] then
+  redis.call("EXPIREAT", KEYS[4], ARGV[5])
+  redis.call("EXPIREAT", KEYS[5], ARGV[5])
+  redis.call("EXPIREAT", KEYS[6], ARGV[5])
+end
 
 -- Remove any jobs that have been given up long enough ago (their score is
 -- below given value)

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -105,7 +105,7 @@ module Pallets
         retry_at = Time.now.to_f + backoff_in_seconds(failures)
         backend.retry(new_job, job, retry_at)
       else
-        backend.give_up(new_job, job)
+        backend.give_up(new_job, job, job_hash['workflow_id'])
         Pallets.logger.info "Gave up after #{failures} failed attempts", extract_metadata(job_hash)
       end
     end
@@ -115,7 +115,7 @@ module Pallets
         'given_up_at' => Time.now.to_f,
         'reason' => 'returned_false'
       ))
-      backend.give_up(new_job, job)
+      backend.give_up(new_job, job, job_hash['workflow_id'])
       Pallets.logger.info "Gave up after returning false", extract_metadata(job_hash)
     end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -387,7 +387,7 @@ describe Pallets::Worker do
       it 'tells the backend to give up the job' do
         Timecop.freeze do
           subject.send(:handle_job_error, ex, job, job_hash)
-          expect(backend).to have_received(:give_up).with('foobar', job)
+          expect(backend).to have_received(:give_up).with('foobar', job, 'qux')
         end
       end
     end
@@ -423,7 +423,7 @@ describe Pallets::Worker do
     it 'tells the backend to give up the job' do
       Timecop.freeze do
         subject.send(:handle_job_return_false, job, job_hash)
-        expect(backend).to have_received(:give_up).with('foobar', job)
+        expect(backend).to have_received(:give_up).with('foobar', job, 'qux')
       end
     end
   end


### PR DESCRIPTION
Currently, when given up jobs are cleaned up, related keys (workflow queue, context and ETA keys) are left behind. We need to properly remove these as well, to keep our backends sane and consistent.