### PR TITLE
Infer pool_size from concurrency

### DIFF
--- a/lib/pallets/configuration.rb
+++ b/lib/pallets/configuration.rb
@@ -25,7 +25,7 @@ module Pallets
     attr_accessor :max_failures
 
     # Number of connections to the backend
-    attr_accessor :pool_size
+    attr_writer :pool_size
 
     # Serializer used for jobs
     attr_accessor :serializer
@@ -38,8 +38,11 @@ module Pallets
       @failed_job_lifespan = 7_776_000 # 3 months
       @job_timeout = 1_800 # 30 minutes
       @max_failures = 3
-      @pool_size = 5
       @serializer = :json
+    end
+
+    def pool_size
+      @pool_size || @concurrency + 1
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Pallets::Configuration do
+  describe '#pool_size' do
+    context 'when explicitly set' do
+      before do
+        subject.pool_size = 123
+      end
+
+      it 'returns the set value' do
+        expect(subject.pool_size).to eq(123)
+      end
+    end
+
+    context 'when not set' do
+      it 'returns the concurrency value plus one' do
+        expect(subject.pool_size).to eq(subject.concurrency + 1)
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe Pallets::Configuration do
   describe '#pool_size' do
+    before do
+      subject.concurrency = 12
+    end
+
     context 'when explicitly set' do
       before do
         subject.pool_size = 123
@@ -14,7 +18,7 @@ describe Pallets::Configuration do
 
     context 'when not set' do
       it 'returns the concurrency value plus one' do
-        expect(subject.pool_size).to eq(subject.concurrency + 1)
+        expect(subject.pool_size).to eq(13)
       end
     end
   end


### PR DESCRIPTION
Pool size shouldn't necessarily be manually configured; the number of Redis connections should be the number of workers, plus the scheduler.