### PR TITLE
Ensure event is finished before transaction

### DIFF
--- a/lib/pallets/middleware/appsignal_instrumenter.rb
+++ b/lib/pallets/middleware/appsignal_instrumenter.rb
@@ -25,10 +25,11 @@ module Pallets
             transaction.params = filtered_context(context)
             formatted_metadata(job).each { |kv| transaction.set_metadata(*kv) }
             transaction.set_http_or_background_queue_start
-            Appsignal::Transaction.complete_current!
             Appsignal.increment_counter('pallets_job_count', 1, status: job_status || :successful)
           end
         end
+      ensure
+        Appsignal::Transaction.complete_current!
       end
 
       def self.filtered_context(context)


### PR DESCRIPTION
Hi 👋 
I saw you created some middleware for AppSignal in this project, but noticed a small problem. The fix:

---

When `Appsignal::Transaction.complete_current!` is called within a
`Appsignal.instrument` block the event is not properly closed. This is
because the event metadata is only set at the end of the block, after
the transaction is "completed" and closed for modifications.

See:
https://github.com/appsignal/appsignal-ruby/blob/172bf1f37f9ae260a5759e8a31daa7729896a35a/lib/appsignal/helpers/instrumentation.rb#L421-L424

Most likely the event will arrive in AppSignal as an "unknown" event.

By moving the `Appsignal::Transaction.complete_current!` call outside
the `Appsignal.instrument` block the event can be properly finished
before the transaction is "completed" and closed for modifications.