### PR TITLE
Task aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- define task aliases (`task 'Foo', as: 'ActualFoo'`) in order to reuse tasks within a workflow definition (#44)
+
 ## [0.5.1] - 2019-06-01
 ### Changed
 - fix transaction completeness in Appsignal instrumenter (#43)

--- a/examples/aliases.rb
+++ b/examples/aliases.rb
@@ -1,0 +1,28 @@
+require 'pallets'
+
+class Aliases < Pallets::Workflow
+  task 'StartSmtpServer'
+  task 'SendEmail', as: 'SayHello', depends_on: 'StartSmtpServer'
+  task 'SendEmail', as: 'SayGoodbye', depends_on: 'StartSmtpServer'
+  task 'StopSmtpServer' => ['SayHello', 'SayGoodbye']
+end
+
+class StartSmtpServer < Pallets::Task
+  def run
+    puts "Starting SMTP server..."
+  end
+end
+
+class SendEmail < Pallets::Task
+  def run
+    puts "* sending e-mail"
+  end
+end
+
+class StopSmtpServer < Pallets::Task
+  def run
+    puts "Stopped SMTP server"
+  end
+end
+
+Aliases.new.run

--- a/lib/pallets/dsl/workflow.rb
+++ b/lib/pallets/dsl/workflow.rb
@@ -1,7 +1,7 @@
 module Pallets
   module DSL
     module Workflow
-      def task(arg, depends_on: nil, max_failures: nil, &block)
+      def task(arg, as: nil, depends_on: nil, max_failures: nil, &block)
         klass, dependencies = case arg
         when Hash
           # The `task Foo => Bar` notation
@@ -12,10 +12,12 @@ module Pallets
         end
 
         task_class = klass.to_s
-        dependencies = Array(dependencies).compact.uniq.map(&:to_s)
-        graph.add(task_class, dependencies)
+        as ||= task_class
 
-        task_config[task_class] = {
+        dependencies = Array(dependencies).compact.uniq.map(&:to_s)
+        graph.add(as, dependencies)
+
+        task_config[as] = {
           'task_class' => task_class,
           'max_failures' => max_failures || Pallets.configuration.max_failures
         }

--- a/lib/pallets/graph.rb
+++ b/lib/pallets/graph.rb
@@ -9,15 +9,15 @@ module Pallets
     end
 
     def add(node, dependencies)
-      @nodes[node] = dependencies
+      nodes[node] = dependencies
     end
 
     def parents(node)
-      @nodes[node]
+      nodes[node]
     end
 
     def empty?
-      @nodes.empty?
+      nodes.empty?
     end
 
     # Returns nodes topologically sorted, together with their order (number of
@@ -37,12 +37,14 @@ module Pallets
 
     private
 
+    attr_reader :nodes
+
     def tsort_each_node(&block)
-      @nodes.each_key(&block)
+      nodes.each_key(&block)
     end
 
     def tsort_each_child(node, &block)
-      @nodes.fetch(node).each(&block)
+      nodes.fetch(node).each(&block)
     rescue KeyError
       raise WorkflowError, "Task #{node} is marked as a dependency but not defined"
     end

--- a/lib/pallets/graph.rb
+++ b/lib/pallets/graph.rb
@@ -9,6 +9,10 @@ module Pallets
     end
 
     def add(node, dependencies)
+      raise WorkflowError, "Task #{node} is already defined in this workflow. "\
+                           "Use `task '#{node}', as: 'FooBar'` to define an "\
+                           "alias and reuse task" if nodes.key?(node)
+
       nodes[node] = dependencies
     end
 

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -25,19 +25,19 @@ module Pallets
     private
 
     def jobs_with_order
-      self.class.graph.sorted_with_order.map do |task_class, order|
-        job = serializer.dump(construct_job(task_class))
+      self.class.graph.sorted_with_order.map do |task_alias, order|
+        job = serializer.dump(construct_job(task_alias))
         [order, job]
       end
     end
 
-    def construct_job(task_class)
-      {}.tap do |job|
+    def construct_job(task_alias)
+      Hash[self.class.task_config[task_alias]].tap do |job|
         job['wfid'] = id
-        job['jid'] = "J#{Pallets::Util.generate_id(task_class)}".upcase
         job['workflow_class'] = self.class.name
+        job['jid'] = "J#{Pallets::Util.generate_id(job['task_class'])}".upcase
         job['created_at'] = Time.now.to_f
-      end.merge(self.class.task_config[task_class])
+      end
     end
 
     def backend

--- a/spec/dsl/workflow_spec.rb
+++ b/spec/dsl/workflow_spec.rb
@@ -23,6 +23,11 @@ describe Pallets::DSL::Workflow do
         subject.class_eval { task 'Eat' }
       end
 
+      context 'and with :as' do
+        it 'identifies the name as :as and no dependencies' do
+          expect(subject.graph).to receive(:add).with('ActuallyEat', [])
+          subject.class_eval { task 'Eat', as: 'ActuallyEat' }
+        end
       end
 
       it 'handles classes' do
@@ -38,6 +43,11 @@ describe Pallets::DSL::Workflow do
         subject.class_eval { task 'BuyFood', depends_on: 'EarnMoney' }
       end
 
+      context 'and with :as' do
+        it 'identifies the name as :as and dependencies from :depends_on' do
+          expect(subject.graph).to receive(:add).with('ActuallyBuyFood', ['EarnMoney'])
+          subject.class_eval { task 'BuyFood', as: 'ActuallyBuyFood', depends_on: 'EarnMoney' }
+        end
       end
 
       it 'handles classes' do
@@ -59,6 +69,11 @@ describe Pallets::DSL::Workflow do
         subject.class_eval { task 'Drink' => 'GetThirstiness' }
       end
 
+      context 'and with :as' do
+        it 'identifies the name as :as and dependencies as the first value' do
+          expect(subject.graph).to receive(:add).with('ActuallyDrink', ['GetThirstiness'])
+          subject.class_eval { task 'Drink', as: 'ActuallyDrink', depends_on: 'GetThirstiness' }
+        end
       end
 
       it 'handles classes' do

--- a/spec/graph_spec.rb
+++ b/spec/graph_spec.rb
@@ -6,6 +6,16 @@ describe Pallets::Graph do
       subject.add('Foo', ['Bar'])
       expect(subject.send(:nodes)).to match('Foo' => ['Bar'])
     end
+
+    context 'with a node that already exists' do
+      before do
+        subject.add('Foo', [])
+      end
+
+      it 'raises a WorkflowError' do
+        expect { subject.add('Foo', ['Bar']) }.to raise_error(Pallets::WorkflowError)
+      end
+    end
   end
 
   describe '#parents' do

--- a/spec/graph_spec.rb
+++ b/spec/graph_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Pallets::Graph do
+  describe '#add' do
+    it 'adds node and its dependencies' do
+      subject.add('Foo', ['Bar'])
+      expect(subject.send(:nodes)).to match('Foo' => ['Bar'])
+    end
+  end
+
   describe '#parents' do
     before do
       subject.add('Foo', [])

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -8,9 +8,9 @@ describe Pallets::Workflow do
 
   class TestWorkflow < Pallets::Workflow
     task 'Foo'
-    task 'Bar' => 'Foo'
+    task 'Bar', as: 'ActualBar', depends_on: 'Foo'
     task 'Baz' => 'Foo'
-    task 'Qux' => 'Bar'
+    task 'Qux' => 'ActualBar'
   end
 
   class EmptyWorkflow < Pallets::Workflow


### PR DESCRIPTION
Adds the ability to define task aliases, in order to reuse tasks within a workflow definition:

```ruby
class Aliases < Pallets::Workflow
  task 'StartSmtpServer'
  task 'SendEmail', as: 'SayHello', depends_on: 'StartSmtpServer'
  task 'SendEmail', as: 'SayGoodbye', depends_on: 'StartSmtpServer'
  task 'StopSmtpServer' => ['SayHello', 'SayGoodbye']
end
```