### PR TITLE
Define anonymous workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - define task aliases (`task 'Foo', as: 'ActualFoo'`) in order to reuse tasks within a workflow definition (#44)
+- define anonymous workflows (`Pallets::Workflow.build(&block)`) (#45)
 
 ## [0.5.1] - 2019-06-01
 ### Changed

--- a/examples/anonymous.rb
+++ b/examples/anonymous.rb
@@ -1,0 +1,13 @@
+require 'pallets'
+
+class Anonymous < Pallets::Task
+  def run
+    puts 'This is anonymous!'
+  end
+end
+
+workflow = Pallets::Workflow.build do
+  task 'Anonymous'
+end
+
+workflow.new.run

--- a/lib/pallets/dsl/workflow.rb
+++ b/lib/pallets/dsl/workflow.rb
@@ -18,6 +18,7 @@ module Pallets
         graph.add(as, dependencies)
 
         task_config[as] = {
+          'workflow_class' => self.name,
           'task_class' => task_class,
           'max_failures' => max_failures || Pallets.configuration.max_failures
         }

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -40,7 +40,6 @@ module Pallets
     def construct_job(task_alias)
       Hash[self.class.task_config[task_alias]].tap do |job|
         job['wfid'] = id
-        job['workflow_class'] = self.class.name
         job['jid'] = "J#{Pallets::Util.generate_id(job['task_class'])}".upcase
         job['created_at'] = Time.now.to_f
       end

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -5,9 +5,9 @@ module Pallets
     attr_reader :context
 
     def self.build(&block)
-      workflow_class = Class.new(self)
-      workflow_class.instance_eval(&block)
-      workflow_class
+      Class.new(self).tap do |workflow_class|
+        workflow_class.instance_eval(&block)
+      end
     end
 
     def initialize(context_hash = {})

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -54,6 +54,10 @@ module Pallets
       Pallets.serializer
     end
 
+    def self.name
+      @name ||= super || '<Anonymous>'
+    end
+
     def self.task_config
       @task_config ||= {}
     end

--- a/lib/pallets/workflow.rb
+++ b/lib/pallets/workflow.rb
@@ -4,6 +4,12 @@ module Pallets
 
     attr_reader :context
 
+    def self.build(&block)
+      workflow_class = Class.new(self)
+      workflow_class.instance_eval(&block)
+      workflow_class
+    end
+
     def initialize(context_hash = {})
       @id = nil
       # Passed in context hash needs to be buffered

--- a/spec/dsl/workflow_spec.rb
+++ b/spec/dsl/workflow_spec.rb
@@ -101,6 +101,13 @@ describe Pallets::DSL::Workflow do
       )
     end
 
+    it 'configures the task with the workflow class name' do
+      subject.class_eval { task 'Pay' }
+      expect(subject.task_config).to match(
+        'Pay' => a_hash_including('workflow_class' => 'Class')
+      )
+    end
+
     context 'with a :max_failures option provided' do
       it 'configures the task with the given value' do
         subject.class_eval { task 'Pay', max_failures: 1 }

--- a/spec/dsl/workflow_spec.rb
+++ b/spec/dsl/workflow_spec.rb
@@ -104,7 +104,7 @@ describe Pallets::DSL::Workflow do
     it 'configures the task with the workflow class name' do
       subject.class_eval { task 'Pay' }
       expect(subject.task_config).to match(
-        'Pay' => a_hash_including('workflow_class' => 'Class')
+        'Pay' => a_hash_including('workflow_class' => '<Anonymous>')
       )
     end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -24,6 +24,20 @@ describe Pallets::Workflow do
     allow(subject).to receive(:backend).and_return(backend)
   end
 
+  describe '.build' do
+    it 'returns a subclass of Pallets::Workflow' do
+      workflow = Pallets::Workflow.build { }
+      expect(workflow).to be < Pallets::Workflow
+    end
+
+    it 'evaluates the workflow definition' do
+      workflow = Pallets::Workflow.build do
+        task 'Foo'
+      end
+      expect(workflow.graph.send(:nodes)).to match('Foo' => [])
+    end
+  end
+
   it 'initializes a new context and buffers given context hash' do
     subject
     expect(context_class).to have_received(:new)

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -100,4 +100,22 @@ describe Pallets::Workflow do
       end
     end
   end
+
+  describe '.name' do
+    context 'for a regular workflow' do
+      let(:workflow) { TestWorkflow }
+
+      it 'returns the class name' do
+        expect(workflow.name).to eq('TestWorkflow')
+      end
+    end
+
+    context 'for an anonymous workflow' do
+      let(:workflow) { Pallets::Workflow.build { } }
+
+      it 'returns <Anonymous>' do
+        expect(workflow.name).to eq('<Anonymous>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows defining anonymous workflows:

```ruby
workflow = Pallets::Workflow.build do
  # ...
end
```