### PR TITLE
Add Ruby 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_install:
   # Bundler 2.0 needs a newer RubyGems
   - gem update --system
   - gem install bundler
+  - 2.7.0
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,5 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
-before_install:
-  # Bundler 2.0 needs a newer RubyGems
-  - gem update --system
-  - gem install bundler
   - 2.7.0
 script: bundle exec rspec

--- a/lib/pallets/dsl/workflow.rb
+++ b/lib/pallets/dsl/workflow.rb
@@ -1,7 +1,13 @@
 module Pallets
   module DSL
     module Workflow
-      def task(arg, as: nil, depends_on: nil, max_failures: nil, &block)
+      def task(arg=nil, as: nil, depends_on: nil, max_failures: nil, **kwargs)
+        # Have to work more to keep Pallets' nice DSL valid in Ruby 2.7
+        arg = !kwargs.empty? ? kwargs : arg
+        raise ArgumentError, 'Task is incorrectly defined. It must receive '\
+                             'either a name, or a name => dependencies pair as '\
+                             'the first argument' unless arg
+
         klass, dependencies = case arg
         when Hash
           # The `task Foo => Bar` notation

--- a/spec/dsl/workflow_spec.rb
+++ b/spec/dsl/workflow_spec.rb
@@ -72,7 +72,7 @@ describe Pallets::DSL::Workflow do
       context 'and with :as' do
         it 'identifies the name as :as and dependencies as the first value' do
           expect(subject.graph).to receive(:add).with('ActuallyDrink', ['GetThirstiness'])
-          subject.class_eval { task 'Drink', as: 'ActuallyDrink', depends_on: 'GetThirstiness' }
+          subject.class_eval { task 'Drink' => 'GetThirstiness', as: 'ActuallyDrink' }
         end
       end
 


### PR DESCRIPTION
Ruby 2.7 came out! Needed to rework a bit the task definition DSL, so it continues to support Pallets' nice way of defining workflows.