### PR TITLE
Configure custom logger

### DIFF
--- a/examples/config_savvy.rb
+++ b/examples/config_savvy.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'pallets'
 
 class AnnounceProcessing
@@ -31,6 +32,8 @@ Pallets.configure do |c|
   # given up. Retry times are exponential and happen after: 7, 22, 87, 262, ...
   c.max_failures = 5
 
+  # Custom loggers can be used too
+  c.logger = Logger.new(STDOUT)
   # Job execution can be wrapped with middleware to provide custom logic.
   # Anything that responds to `call` would do
   c.middleware << AnnounceProcessing

--- a/lib/pallets.rb
+++ b/lib/pallets.rb
@@ -57,13 +57,6 @@ module Pallets
   end
 
   def self.logger
-    @logger ||= Pallets::Logger.new(STDOUT,
-      level: Pallets::Logger::INFO,
-      formatter: Pallets::Logger::Formatters::Pretty.new
-    )
-  end
-
-  def self.logger=(logger)
-    @logger = logger
+    @logger ||= configuration.logger
   end
 end

--- a/lib/pallets/configuration.rb
+++ b/lib/pallets/configuration.rb
@@ -20,6 +20,9 @@ module Pallets
     # period, it is considered failed, and scheduled to be processed again
     attr_accessor :job_timeout
 
+    # Custom logger used throughout Pallets
+    attr_writer :logger
+
     # Maximum number of failures allowed per job. Can also be configured on a
     # per task basis
     attr_accessor :max_failures
@@ -49,6 +52,13 @@ module Pallets
       @max_failures = 3
       @serializer = :json
       @middleware = default_middleware
+    end
+
+    def logger
+      @logger || Pallets::Logger.new(STDOUT,
+        level: Pallets::Logger::INFO,
+        formatter: Pallets::Logger::Formatters::Pretty.new
+      )
     end
 
     def pool_size

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,26 @@
 require 'spec_helper'
 
 describe Pallets::Configuration do
+  describe '#logger' do
+    context 'when explicitly set' do
+      let(:logger) { Logger.new(STDOUT) }
+      
+      before do
+        subject.logger = logger
+      end
+
+      it 'returns the set logger' do
+        expect(subject.logger).to be(logger)
+      end
+    end
+
+    context 'when not set' do
+      it 'returns the default logger' do
+        expect(subject.logger).to be_a(Pallets::Logger)
+      end
+    end
+  end
+
   describe '#pool_size' do
     before do
       subject.concurrency = 12


### PR DESCRIPTION
Enables configuring custom loggers:

```ruby
Pallets.configure do |c|
  c.logger = Logger.new(STDOUT)
end
```