### PR TITLE
Don’t give up workflow when task returns false anymore

### DIFF
--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -76,17 +76,13 @@ module Pallets
       task_class = Pallets::Util.constantize(job_hash["task_class"])
       task = task_class.new(context)
       begin
-        task_result = middleware.invoke(self, job_hash, context) do
+        middleware.invoke(self, job_hash, context) do
           task.run
         end
       rescue => ex
         handle_job_error(ex, job, job_hash)
       else
-        if task_result == false
-          handle_job_return_false(job, job_hash)
-        else
-          handle_job_success(context, job, job_hash)
-        end
+        handle_job_success(context, job, job_hash)
       end
     end
 
@@ -105,14 +101,6 @@ module Pallets
       else
         backend.give_up(new_job, job)
       end
-    end
-
-    def handle_job_return_false(job, job_hash)
-      new_job = serializer.dump(job_hash.merge(
-        'given_up_at' => Time.now.to_f,
-        'reason' => 'returned_false'
-      ))
-      backend.give_up(new_job, job)
     end
 
     def handle_job_success(context, job, job_hash)

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -201,7 +201,6 @@ describe Pallets::Worker do
       # Stub middleware invocation, but call the provided block
       allow(middleware).to receive(:invoke) { |&block| block.call }
       allow(subject).to receive(:handle_job_error)
-      allow(subject).to receive(:handle_job_return_false)
       allow(subject).to receive(:handle_job_success)
     end
 
@@ -241,7 +240,6 @@ describe Pallets::Worker do
       it 'does not invoke any handler' do
         subject.send(:process, job)
         expect(subject).not_to have_received(:handle_job_error)
-        expect(subject).not_to have_received(:handle_job_return_false)
         expect(subject).not_to have_received(:handle_job_success)
       end
     end
@@ -282,17 +280,6 @@ describe Pallets::Worker do
       it 'calls the error handler' do
         subject.send(:process, job)
         expect(subject).to have_received(:handle_job_error).with(a_kind_of(ArgumentError), job, job_hash)
-      end
-    end
-
-    context 'when the task returns false' do
-      before do
-        allow(task).to receive(:run).and_return(false)
-      end
-
-      it 'calls the return false handler' do
-        subject.send(:process, job)
-        expect(subject).to have_received(:handle_job_return_false).with(job, job_hash)
       end
     end
 
@@ -398,42 +385,6 @@ describe Pallets::Worker do
           subject.send(:handle_job_error, ex, job, job_hash)
           expect(backend).to have_received(:give_up).with('foobar', job)
         end
-      end
-    end
-  end
-
-  describe '#handle_job_return_false' do
-    let(:backend) { instance_spy('Pallets::Backends::Base') }
-    let(:serializer) { instance_spy('Pallets::Serializers::Base', dump: 'foobar') }
-    let(:job) { double }
-    let(:job_hash) do
-      {
-        'wfid' => 'qux',
-        'jid' => 'quxqux',
-        'task_class' => 'Foo',
-        'max_failures' => 15
-      }
-    end
-
-    before do
-      allow(subject).to receive(:backend).and_return(backend)
-      allow(subject).to receive(:serializer).and_return(serializer)
-    end
-
-    it 'builds a new job and uses the serializer to dump it' do
-      Timecop.freeze do
-        subject.send(:handle_job_return_false, job, job_hash)
-        expect(serializer).to have_received(:dump).with(job_hash.merge(
-          'given_up_at' => Time.now.to_f,
-          'reason' => 'returned_false'
-        ))
-      end
-    end
-
-    it 'tells the backend to give up the job' do
-      Timecop.freeze do
-        subject.send(:handle_job_return_false, job, job_hash)
-        expect(backend).to have_received(:give_up).with('foobar', job)
       end
     end
   end


### PR DESCRIPTION
This reverts an earlier change. Workflows are not given up anymore if a task would return false. This was not intuitive and could potentially hide an actual issue within the task. Given up workflows would also be persisted for quite some time, which shouldn't happen, given there was no error or failed task. In the end, this broke Pallets' contract of defining a workflows contract from the beginning and being able to follow execution through all of its tasks; short-circuiting would mean workflows could complete without executing all tasks. A similar behaviour can be achieved by setting a context key and adding check it on the subsequent task(s).