### PR TITLE
Improve scheduling

### DIFF
--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -6,12 +6,12 @@ module Pallets
         raise NotImplementedError
       end
 
-      def get_context(workflow_id)
+      def get_context(wfid)
         raise NotImplementedError
       end
 
       # Saves a job after successfully processing it
-      def save(workflow_id, job, context_buffer)
+      def save(wfid, jid, job, context_buffer)
         raise NotImplementedError
       end
 
@@ -29,7 +29,7 @@ module Pallets
         raise NotImplementedError
       end
 
-      def run_workflow(workflow_id, jobs_with_dependencies, context)
+      def run_workflow(wfid, jobs, jobmasks, context)
         raise NotImplementedError
       end
     end

--- a/lib/pallets/backends/scripts/run_workflow.lua
+++ b/lib/pallets/backends/scripts/run_workflow.lua
@@ -6,9 +6,8 @@ redis.call("SET", KEYS[3], eta)
 
 -- Queue jobs that are ready to be processed (their score is 0) and
 -- remove queued jobs from the sorted set
-local count = redis.call("ZCOUNT", KEYS[1], 0, 0)
-if count > 0 then
-  local work = redis.call("ZRANGEBYSCORE", KEYS[1], 0, 0)
+local work = redis.call("ZRANGEBYSCORE", KEYS[1], 0, 0)
+if #work > 0 then
   redis.call("LPUSH", KEYS[2], unpack(work))
   redis.call("ZREM", KEYS[1], unpack(work))
 end

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -18,16 +18,15 @@ end
 
 -- Queue jobs that are ready to be processed (their score is 0) and
 -- remove queued jobs from sorted set
-local count = redis.call("ZCOUNT", KEYS[1], 0, 0)
-if count > 0 then
-  local work = redis.call("ZRANGEBYSCORE", KEYS[1], 0, 0)
+local work = redis.call("ZRANGEBYSCORE", KEYS[1], 0, 0)
+if #work > 0 then
   redis.call("LPUSH", KEYS[2], unpack(work))
   redis.call("ZREM", KEYS[1], unpack(work))
 end
 
 -- Decrement ETA and remove it together with the context if all tasks have
 -- been processed (ETA is 0)
-redis.call("DECR", KEYS[6])
-if tonumber(redis.call("GET", KEYS[6])) == 0 then
+local remaining = redis.call("DECR", KEYS[6])
+if remaining == 0 then
   redis.call("DEL", KEYS[5], KEYS[6])
 end

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -10,11 +10,9 @@ if #ARGV > 0 then
   redis.call("HMSET", KEYS[5], unpack(ARGV))
 end
 
--- Decrement all jobs from the sorted set
-local all_pending = redis.call("ZRANGE", KEYS[1], 0, -1)
-for score, task in pairs(all_pending) do
-  redis.call("ZINCRBY", KEYS[1], -1, task)
-end
+-- Decrement jobs from the sorted set by applying a jobmask
+redis.call("ZUNIONSTORE", KEYS[1], 2, KEYS[1], KEYS[7])
+redis.call("DEL", KEYS[7])
 
 -- Queue jobs that are ready to be processed (their score is 0) and
 -- remove queued jobs from sorted set

--- a/lib/pallets/graph.rb
+++ b/lib/pallets/graph.rb
@@ -24,18 +24,11 @@ module Pallets
       nodes.empty?
     end
 
-    # Returns nodes topologically sorted, together with their order (number of
-    # nodes that have to be executed prior)
-    def sorted_with_order
-      # Identify groups of nodes that can be executed concurrently
-      groups = tsort_each.slice_when { |a, b| parents(a) != parents(b) }
+    def each
+      return enum_for(__method__) unless block_given?
 
-      # Assign order to each node
-      i = 0
-      groups.flat_map do |group|
-        group_with_order = group.product([i])
-        i += group.size
-        group_with_order
+      tsort_each do |node|
+        yield(node, parents(node))
       end
     end
 

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -116,7 +116,7 @@ module Pallets
     end
 
     def handle_job_success(context, job, job_hash)
-      backend.save(job_hash['wfid'], job, serializer.dump_context(context.buffer))
+      backend.save(job_hash['wfid'], job_hash['jid'], job, serializer.dump_context(context.buffer))
     end
 
     def backoff_in_seconds(count)

--- a/spec/graph_spec.rb
+++ b/spec/graph_spec.rb
@@ -56,7 +56,7 @@ describe Pallets::Graph do
     end
   end
 
-  describe '#sorted_with_order' do
+  describe '#each' do
     let(:graph) do
       Pallets::Graph.new.tap do |g|
         g.add('Foo', [])
@@ -66,10 +66,21 @@ describe Pallets::Graph do
       end
     end
 
-    it 'returns a properly formatted Array' do
-      expect(graph.sorted_with_order).to eq([
-        ['Foo', 0], ['Bar', 1], ['Baz', 1], ['Qux', 3]
-      ])
+    context 'with a given block' do
+      it 'yields the correct elements' do
+        expect { |b| graph.each(&b) }.to yield_successive_args(
+          ['Foo', []], ['Bar', ['Foo']], ['Baz', ['Foo']], ['Qux', ['Bar']]
+        )
+      end
+    end
+
+    context 'without a block' do
+      it 'returns an Enumerator that yields the correct elements' do
+        expect(graph.each).to be_an(Enumerator)
+        expect(graph.each.to_a).to eq([
+          ['Foo', []], ['Bar', ['Foo']], ['Baz', ['Foo']], ['Qux', ['Bar']]
+        ])
+      end
     end
 
     context 'with a dependency that is not defined' do
@@ -80,7 +91,7 @@ describe Pallets::Graph do
       end
 
       it 'raises a WorkflowError' do
-        expect { graph.sorted_with_order }.to raise_error(Pallets::WorkflowError)
+        expect { graph.each.to_a }.to raise_error(Pallets::WorkflowError)
       end
     end
   end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -444,7 +444,8 @@ describe Pallets::Worker do
     let(:job) { double }
     let(:job_hash) do
       {
-        'wfid' => 'qux'
+        'wfid' => 'qux',
+        'jid' => 'bar'
       }
     end
     let(:context) { instance_spy('Pallets::Context', buffer: { foo: :bar }) }
@@ -463,7 +464,7 @@ describe Pallets::Worker do
 
     it 'tells the backend to save the job' do
       subject.send(:handle_job_success, context, job, job_hash)
-      expect(backend).to have_received(:save).with('qux', job, 'bazqux')
+      expect(backend).to have_received(:save).with('qux', 'bar', job, 'bazqux')
     end
   end
 end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -92,11 +92,15 @@ describe Pallets::Workflow do
     end
 
     it 'tells the backend to run the workflow' do
+      allow(Pallets::Util).to receive(:generate_id) { |arg| arg }
       Timecop.freeze do
         subject.run
         expect(backend).to have_received(:run_workflow).with(a_kind_of(String), [
-          [0, 'foobar'], [1, 'foobar'], [1, 'foobar'], [3, 'foobar']
-        ], 'bazqux')
+          [0, 'foobar'], [1, 'foobar'], [1, 'foobar'], [1, 'foobar']
+        ], {
+          'JFOO' => [[-1, 'foobar'], [-1, 'foobar']],
+          'JBAR' => [[-1, 'foobar']]
+        }, 'bazqux')
       end
     end
   end


### PR DESCRIPTION
This introduces jobmasks to model and schedule task dependencies in a more efficient way. 

Previously, tasks executed in parallel could sometimes depend on tasks from different branches, delaying their scheduling and thus affecting workflow performance. This happened because pending jobs were keeping an absolute dependency count that got decremented by 1 on every successful job.

With jobmasks (kindof like _bitmasks_, but for jobs), pending jobs are now keeping a relative dependency count that is only decremented when an **actual** dependency job is successful.

Besides this, a few tweaks have been applied to existing Lua scripts to use less Redis commands or use others more efficiently.