### PR TITLE
Remove all related workflow keys when giving up on a job

### DIFF
--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -21,7 +21,7 @@ module Pallets
       end
 
       # Gives up job after repeteadly failing to process it
-      def give_up(job, old_job)
+      def give_up(job, old_job, wfid)
         raise NotImplementedError
       end
 

--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -26,7 +26,7 @@ module Pallets
       end
 
       # Gives up job after repeteadly failing to process it
-      def give_up(job, old_job, wfid)
+      def give_up(wfid, job, old_job)
         raise NotImplementedError
       end
 

--- a/lib/pallets/backends/base.rb
+++ b/lib/pallets/backends/base.rb
@@ -20,6 +20,11 @@ module Pallets
         raise NotImplementedError
       end
 
+      # Discards malformed job
+      def discard(job)
+        raise NotImplementedError
+      end
+
       # Gives up job after repeteadly failing to process it
       def give_up(job, old_job, wfid)
         raise NotImplementedError

--- a/lib/pallets/backends/redis.rb
+++ b/lib/pallets/backends/redis.rb
@@ -64,6 +64,16 @@ module Pallets
         end
       end
 
+      def discard(job)
+        @pool.execute do |client|
+          client.evalsha(
+            @scripts['discard'],
+            [GIVEN_UP_SET_KEY, RELIABILITY_QUEUE_KEY, RELIABILITY_SET_KEY],
+            [Time.now.to_f, job, Time.now.to_f - @failed_job_lifespan, @failed_job_max_count]
+          )
+        end
+      end
+
       def give_up(wfid, job, old_job)
         @pool.execute do |client|
           client.evalsha(

--- a/lib/pallets/backends/redis.rb
+++ b/lib/pallets/backends/redis.rb
@@ -9,6 +9,7 @@ module Pallets
       RETRY_SET_KEY = 'retry-set'
       GIVEN_UP_SET_KEY = 'given-up-set'
       WORKFLOW_QUEUE_KEY = 'workflow-queue:%s'
+      JOBMASKS_KEY = 'jobmasks:%s'
       JOBMASK_KEY = 'jobmask:%s'
       CONTEXT_KEY = 'context:%s'
       REMAINING_KEY = 'remaining:%s'
@@ -47,7 +48,7 @@ module Pallets
         @pool.execute do |client|
           client.evalsha(
             @scripts['save'],
-            [WORKFLOW_QUEUE_KEY % wfid, QUEUE_KEY, RELIABILITY_QUEUE_KEY, RELIABILITY_SET_KEY, CONTEXT_KEY % wfid, REMAINING_KEY % wfid, JOBMASK_KEY % jid],
+            [WORKFLOW_QUEUE_KEY % wfid, QUEUE_KEY, RELIABILITY_QUEUE_KEY, RELIABILITY_SET_KEY, CONTEXT_KEY % wfid, REMAINING_KEY % wfid, JOBMASK_KEY % jid, JOBMASKS_KEY % wfid],
             context_buffer.to_a << job
           )
         end
@@ -87,6 +88,7 @@ module Pallets
         @pool.execute do |client|
           client.multi do
             jobmasks.each { |jid, jobmask| client.zadd(JOBMASK_KEY % jid, jobmask) }
+            client.sadd(JOBMASKS_KEY % wfid, jobmasks.map { |jid, _| JOBMASK_KEY % jid }) unless jobmasks.empty?
             client.evalsha(
               @scripts['run_workflow'],
               [WORKFLOW_QUEUE_KEY % wfid, QUEUE_KEY, REMAINING_KEY % wfid],

--- a/lib/pallets/backends/redis.rb
+++ b/lib/pallets/backends/redis.rb
@@ -64,11 +64,11 @@ module Pallets
         end
       end
 
-      def give_up(job, old_job)
+      def give_up(wfid, job, old_job)
         @pool.execute do |client|
           client.evalsha(
             @scripts['give_up'],
-            [GIVEN_UP_SET_KEY, RELIABILITY_QUEUE_KEY, RELIABILITY_SET_KEY],
+            [GIVEN_UP_SET_KEY, RELIABILITY_QUEUE_KEY, RELIABILITY_SET_KEY, JOBMASKS_KEY % wfid, WORKFLOW_QUEUE_KEY % wfid, REMAINING_KEY % wfid, CONTEXT_KEY % wfid],
             [Time.now.to_f, job, old_job, Time.now.to_f - @failed_job_lifespan, @failed_job_max_count]
           )
         end

--- a/lib/pallets/backends/scripts/discard.lua
+++ b/lib/pallets/backends/scripts/discard.lua
@@ -1,0 +1,11 @@
+-- Remove job from reliability queue
+redis.call("LREM", KEYS[2], 0, ARGV[2])
+redis.call("ZREM", KEYS[3], ARGV[2])
+
+-- Add job and its fail time (score) to failed sorted set
+redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+
+-- Remove any jobs that have been given up long enough ago (their score is
+-- below given value) and make sure the number of jobs is capped
+redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[3])
+redis.call("ZREMRANGEBYRANK", KEYS[1], 0, -ARGV[4] - 1)

--- a/lib/pallets/backends/scripts/give_up.lua
+++ b/lib/pallets/backends/scripts/give_up.lua
@@ -5,6 +5,10 @@ redis.call("ZREM", KEYS[3], ARGV[3])
 -- Add job and its fail time (score) to failed sorted set
 redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
 
+-- Remove all related workflow keys
+local keys = redis.call("SMEMBERS", KEYS[4])
+redis.call("DEL", KEYS[4], KEYS[5], KEYS[6], KEYS[7], unpack(keys))
+
 -- Remove any jobs that have been given up long enough ago (their score is
 -- below given value) and make sure the number of jobs is capped
 redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[4])

--- a/lib/pallets/backends/scripts/save.lua
+++ b/lib/pallets/backends/scripts/save.lua
@@ -22,9 +22,9 @@ if #work > 0 then
   redis.call("ZREM", KEYS[1], unpack(work))
 end
 
--- Decrement ETA and remove it together with the context if all tasks have
--- been processed (ETA is 0)
+-- Decrement ETA and remove it together with the context and jobmasks if all
+-- tasks have been processed (ETA is 0) or if workflow has been given up (ETA is -1)
 local remaining = redis.call("DECR", KEYS[6])
-if remaining == 0 then
-  redis.call("DEL", KEYS[5], KEYS[6])
+if remaining <= 0 then
+  redis.call("DEL", KEYS[5], KEYS[6], KEYS[8])
 end

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -103,7 +103,7 @@ module Pallets
         retry_at = Time.now.to_f + backoff_in_seconds(failures)
         backend.retry(new_job, job, retry_at)
       else
-        backend.give_up(new_job, job)
+        backend.give_up(job_hash['wfid'], new_job, job)
       end
     end
 
@@ -112,7 +112,7 @@ module Pallets
         'given_up_at' => Time.now.to_f,
         'reason' => 'returned_false'
       ))
-      backend.give_up(new_job, job)
+      backend.give_up(job_hash['wfid'], new_job, job)
     end
 
     def handle_job_success(context, job, job_hash)

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -64,7 +64,7 @@ module Pallets
       rescue
         # We ensure only valid jobs are created. If something fishy reaches this
         # point, just give up on it
-        backend.give_up(job, job)
+        backend.discard(job)
         Pallets.logger.error "Could not deserialize #{job}. Gave up job", wid: id
         return
       end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -216,10 +216,10 @@ describe Pallets::Worker do
         allow(serializer).to receive(:load).and_raise(ArgumentError)
       end
 
-      it 'tells the backend to give up on the job' do
+      it 'tells the backend to discard the job' do
         Timecop.freeze do
           subject.send(:process, job)
-          expect(backend).to have_received(:give_up).with(job, job)
+          expect(backend).to have_received(:discard).with(job)
         end
       end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -396,7 +396,7 @@ describe Pallets::Worker do
       it 'tells the backend to give up the job' do
         Timecop.freeze do
           subject.send(:handle_job_error, ex, job, job_hash)
-          expect(backend).to have_received(:give_up).with('foobar', job)
+          expect(backend).to have_received(:give_up).with('qux', 'foobar', job)
         end
       end
     end
@@ -433,7 +433,7 @@ describe Pallets::Worker do
     it 'tells the backend to give up the job' do
       Timecop.freeze do
         subject.send(:handle_job_return_false, job, job_hash)
-        expect(backend).to have_received(:give_up).with('foobar', job)
+        expect(backend).to have_received(:give_up).with('qux', 'foobar', job)
       end
     end
   end


### PR DESCRIPTION
This removes all related workflow keys when giving up on a job. Previously, these keys were never deleted by Pallets, which contributed to an ever-increasing keyspace.

Given up jobs are only meant to be inspected for errors, so there is no point in keeping anything else related to the failed job.

Closes #35 