### PR TITLE
Cleaner logger

### DIFF
--- a/examples/config_savvy.rb
+++ b/examples/config_savvy.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require 'pallets'
 
 class AnnounceProcessing
@@ -32,8 +31,6 @@ Pallets.configure do |c|
   # given up. Retry times are exponential and happen after: 7, 22, 87, 262, ...
   c.max_failures = 5
 
-  # Custom loggers can be used too
-  c.logger = Logger.new(STDOUT)
   # Job execution can be wrapped with middleware to provide custom logic.
   # Anything that responds to `call` would do
   c.middleware << AnnounceProcessing

--- a/lib/pallets.rb
+++ b/lib/pallets.rb
@@ -58,6 +58,9 @@ module Pallets
   end
 
   def self.logger
-    @logger ||= configuration.logger
+    @logger ||= Pallets::Logger.new(STDOUT,
+      level: Pallets::Logger::INFO,
+      formatter: Pallets::Logger::Formatters::Pretty.new
+    )
   end
 end

--- a/lib/pallets/configuration.rb
+++ b/lib/pallets/configuration.rb
@@ -24,9 +24,6 @@ module Pallets
     # period, it is considered failed, and scheduled to be processed again
     attr_accessor :job_timeout
 
-    # Custom logger used throughout Pallets
-    attr_writer :logger
-
     # Maximum number of failures allowed per job. Can also be configured on a
     # per task basis
     attr_accessor :max_failures
@@ -57,13 +54,6 @@ module Pallets
       @max_failures = 3
       @serializer = :json
       @middleware = default_middleware
-    end
-
-    def logger
-      @logger || Pallets::Logger.new(STDOUT,
-        level: Pallets::Logger::INFO,
-        formatter: Pallets::Logger::Formatters::Pretty.new
-      )
     end
 
     def pool_size

--- a/lib/pallets/logger.rb
+++ b/lib/pallets/logger.rb
@@ -5,12 +5,20 @@ module Pallets
   class Logger < ::Logger
     # Overwrite severity methods to add metadata capabilities
     %i[debug info warn error fatal unknown].each do |severity|
-      define_method severity do |message, metadata = {}|
-        return super(message) if metadata.empty?
+      define_method severity do |message|
+        metadata = Thread.current[:pallets_log_metadata]
+        return super(message) if metadata.nil?
 
         formatted_metadata = ' ' + metadata.map { |k, v| "#{k}=#{v}" }.join(' ')
         super(formatted_metadata) { message }
       end
+    end
+
+    def with_metadata(hash)
+      Thread.current[:pallets_log_metadata] = hash
+      yield
+    ensure
+      Thread.current[:pallets_log_metadata] = nil
     end
 
     module Formatters

--- a/lib/pallets/middleware/job_logger.rb
+++ b/lib/pallets/middleware/job_logger.rb
@@ -5,15 +5,17 @@ module Pallets
         start_time = current_time
 
         Pallets.logger.with_metadata(extract_metadata(worker.id, job)) do
-          Pallets.logger.info 'Started'
-          result = yield
-          Pallets.logger.info "Done in #{(current_time - start_time).round(3)}s"
-          result
-        rescue => ex
-          Pallets.logger.warn "Failed after #{(current_time - start_time).round(3)}s"
-          Pallets.logger.warn "#{ex.class.name}: #{ex.message}"
-          Pallets.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
-          raise
+          begin
+            Pallets.logger.info 'Started'
+            result = yield
+            Pallets.logger.info "Done in #{(current_time - start_time).round(3)}s"
+            result
+          rescue => ex
+            Pallets.logger.warn "Failed after #{(current_time - start_time).round(3)}s"
+            Pallets.logger.warn "#{ex.class.name}: #{ex.message}"
+            Pallets.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
+            raise
+          end
         end
       end
 

--- a/lib/pallets/middleware/job_logger.rb
+++ b/lib/pallets/middleware/job_logger.rb
@@ -2,13 +2,15 @@ module Pallets
   module Middleware
     class JobLogger
       def self.call(worker, job, context)
+        start_time = current_time
+
         Pallets.logger.with_metadata(extract_metadata(worker.id, job)) do
           Pallets.logger.info 'Started'
           result = yield
-          Pallets.logger.info 'Done'
+          Pallets.logger.info "Done in #{(current_time - start_time).round(3)}s"
           result
         rescue => ex
-          Pallets.logger.warn 'Failed'
+          Pallets.logger.warn "Failed after #{(current_time - start_time).round(3)}s"
           Pallets.logger.warn "#{ex.class.name}: #{ex.message}"
           Pallets.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
           raise
@@ -23,6 +25,10 @@ module Pallets
           wf:   job['workflow_class'],
           tsk:  job['task_class'],
         }
+      end
+
+      def self.current_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
   end

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -53,8 +53,8 @@ module Pallets
     rescue Pallets::Shutdown
       @manager.remove_worker(self)
     rescue => ex
-      Pallets.logger.error "#{ex.class.name}: #{ex.message}", wid: id
-      Pallets.logger.error ex.backtrace.join("\n"), wid: id unless ex.backtrace.nil?
+      Pallets.logger.error "#{ex.class.name}: #{ex.message}"
+      Pallets.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
       @manager.replace_worker(self)
     end
 
@@ -65,7 +65,7 @@ module Pallets
         # We ensure only valid jobs are created. If something fishy reaches this
         # point, just give up on it
         backend.give_up(job, job)
-        Pallets.logger.error "Could not deserialize #{job}. Gave up job", wid: id
+        Pallets.logger.error "Could not deserialize #{job}. Gave up job"
         return
       end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,26 +1,6 @@
 require 'spec_helper'
 
 describe Pallets::Configuration do
-  describe '#logger' do
-    context 'when explicitly set' do
-      let(:logger) { Logger.new(STDOUT) }
-      
-      before do
-        subject.logger = logger
-      end
-
-      it 'returns the set logger' do
-        expect(subject.logger).to be(logger)
-      end
-    end
-
-    context 'when not set' do
-      it 'returns the default logger' do
-        expect(subject.logger).to be_a(Pallets::Logger)
-      end
-    end
-  end
-
   describe '#pool_size' do
     before do
       subject.concurrency = 12

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -30,7 +30,9 @@ describe Pallets::Logger do
 
       context 'with metadata' do
         it 'invokes the formatter with the correct arguments' do
-          subject.send(severity, 'foo', { foo: :bar, baz: :qux })
+          subject.with_metadata(foo: :bar, baz: :qux) do
+            subject.send(severity, 'foo')
+          end
           expect(formatter).to have_received(:call).with(
             formatted_severity, a_kind_of(Time), ' foo=bar baz=qux', 'foo'
           )
@@ -39,12 +41,32 @@ describe Pallets::Logger do
     end
   end
 
+  describe '#with_metadata' do
+    it 'yields to the given block' do
+      expect { |b| subject.with_metadata(foo: :bar, &b) }.to yield_control
+    end
+
+    it 'sets a thread local before yielding to the given block' do
+      b = -> { expect(Thread.current[:pallets_log_metadata]).to eq(foo: :bar) }
+      subject.with_metadata(foo: :bar, &b)
+    end
+
+    it 'removes the thread local after yielding to the given block' do
+      subject.with_metadata(foo: :bar) do
+        subject.info('foo')
+      end
+      expect(Thread.current[:pallets_log_metadata]).to be_nil
+    end
+  end
+
   context 'using the Pretty formatter' do
     let(:formatter) { Pallets::Logger::Formatters::Pretty.new }
 
     it 'formats the message correctly' do
       Timecop.freeze do
-        subject.info('foo', { foo: :bar })
+        subject.with_metadata(foo: :bar) do
+          subject.info('foo')
+        end
         expect(output.string).to match(
           /#{Time.now.utc.iso8601(4)} pid=\d+ foo=bar INFO: foo\n/
         )


### PR DESCRIPTION
This introduces thread locals to maintain job metadata throughout all log invocations from within jobs. It also removes support for custom loggers (introduced in #50) and adds duration to job logs.