### PR TITLE
Sleep a bit in case of persisting unforeseen worker errors

### DIFF
--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -55,6 +55,8 @@ module Pallets
     rescue => ex
       Pallets.logger.error "#{ex.class.name}: #{ex.message}"
       Pallets.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
+      # Do not flood the process in case of persisting unforeseen errors
+      sleep 1
       @manager.replace_worker(self)
     end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -92,6 +92,8 @@ describe Pallets::Worker do
       allow(subject).to receive(:loop).and_yield
       allow(subject).to receive(:backend).and_return(backend)
       allow(subject).to receive(:process).with(job)
+      # Do not *actually* sleep
+      allow(subject).to receive(:sleep)
     end
 
     it 'tells the backend to pick work' do
@@ -158,6 +160,11 @@ describe Pallets::Worker do
       before do
         # Simulate an unexpected non-job error that occurs while working
         allow(backend).to receive(:pick).and_raise(ArgumentError)
+      end
+
+      it 'waits for a second before doing anything' do
+        subject.send(:work)
+        expect(subject).to have_received(:sleep).with(1).once
       end
 
       it 'asks the manager to replace itself' do


### PR DESCRIPTION
Otherwise we would flood the process with recycled workers and log messages.