### PR TITLE
Scheduler improvements

### DIFF
--- a/lib/pallets/cli.rb
+++ b/lib/pallets/cli.rb
@@ -63,6 +63,10 @@ module Pallets
           Pallets.configuration.max_failures = max_failures
         end
 
+        opts.on('-i', '--scheduler-polling-interval NUM', Integer, 'Seconds between scheduler backend polls') do |scheduler_polling_interval|
+          Pallets.configuration.scheduler_polling_interval = scheduler_polling_interval
+        end
+
         opts.on('-l', '--failed-job-lifespan NUM', Integer, 'Seconds a job stays in the given up set') do |failed_job_lifespan|
           Pallets.configuration.failed_job_lifespan = failed_job_lifespan
         end

--- a/lib/pallets/configuration.rb
+++ b/lib/pallets/configuration.rb
@@ -31,6 +31,12 @@ module Pallets
     # Number of connections to the backend
     attr_writer :pool_size
 
+    # Number of seconds at which the scheduler checks whether there are jobs
+    # due to be (re)processed. Note that this interval is per process; it might
+    # require tweaking in case of running multiple Pallets instances, so that
+    # the backend is not polled too often
+    attr_accessor :scheduler_polling_interval
+
     # Serializer used for jobs
     attr_accessor :serializer
 
@@ -52,6 +58,7 @@ module Pallets
       @failed_job_max_count = 1_000
       @job_timeout = 1_800 # 30 minutes
       @max_failures = 3
+      @scheduler_polling_interval = 10
       @serializer = :json
       @middleware = default_middleware
     end

--- a/lib/pallets/scheduler.rb
+++ b/lib/pallets/scheduler.rb
@@ -40,11 +40,11 @@ module Pallets
       end
     end
 
-    def wait_a_bit
-      # Wait for roughly 10 seconds
+    def wait_a_bit(seconds = Pallets.configuration.scheduler_polling_interval)
+      # Wait for roughly the configured number of seconds
       # We don't want to block the entire polling interval, since we want to
       # deal with shutdowns synchronously and as fast as possible
-      10.times do
+      seconds.times do
         break if needs_to_stop?
         sleep 1
       end

--- a/lib/pallets/scheduler.rb
+++ b/lib/pallets/scheduler.rb
@@ -7,7 +7,7 @@ module Pallets
     end
 
     def start
-      @thread ||= Thread.new { work }
+      @thread ||= Thread.new { wait_initial_bit; work }
     end
 
     def shutdown
@@ -38,6 +38,12 @@ module Pallets
         backend.reschedule_all(Time.now.to_f)
         wait_a_bit
       end
+    end
+
+    def wait_initial_bit
+      # Randomly wait a bit before starting working, so that multiple processes
+      # will not hit the backend all at once
+      wait_a_bit(rand(Pallets.configuration.scheduler_polling_interval))
     end
 
     def wait_a_bit(seconds = Pallets.configuration.scheduler_polling_interval)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -57,6 +57,17 @@ describe Pallets::CLI do
     end
   end
 
+  context 'with --scheduler-polling-interval provided' do
+    before do
+      stub_const('ARGV', ['--scheduler-polling-interval=123'])
+    end
+
+    it 'sets the given scheduler polling interval' do
+      subject
+      expect(configuration).to have_received(:scheduler_polling_interval=).with(123)
+    end
+  end
+
   context 'with --failed-job-lifespan provided' do
     before do
       stub_const('ARGV', ['--failed-job-lifespan=123'])

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -86,6 +86,7 @@ describe Pallets::Scheduler do
     let(:backend) { instance_spy('Pallets::Backends::Base') }
 
     before do
+      allow(Pallets.configuration).to receive(:scheduler_polling_interval).and_return(10)
       allow(subject).to receive(:loop).and_yield
       allow(subject).to receive(:backend).and_return(backend)
       # Do not *actually* sleep

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -7,13 +7,21 @@ describe Pallets::Scheduler do
 
   describe '#start' do
     before do
+      allow(Pallets.configuration).to receive(:scheduler_polling_interval).and_return(10)
       allow(Thread).to receive(:new).and_yield
       allow(subject).to receive(:work)
+      # Do not *actually* sleep
+      allow(subject).to receive(:sleep)
     end
 
     it 'creates a separate thread' do
       subject.start
       expect(Thread).to have_received(:new)
+    end
+
+    it 'waits a random number of seconds before it starts working' do
+      subject.start
+      expect(subject).to have_received(:sleep).with(1).at_most(9).times
     end
 
     it 'starts working' do


### PR DESCRIPTION
This PR makes the polling interval for the scheduler configurable, also from the CLI. It allows finer tuning for Pallets setups that have multiple processes and run the chance of polling too often.

It also adds a random initial wait when starting the scheduler, so the polls are spread more evenly in time, avoiding (mostly) the thundering herd problem.

Closes #36 