### PR TITLE
Explictly pass backend from manager to workers and scheduler

### DIFF
--- a/lib/pallets/manager.rb
+++ b/lib/pallets/manager.rb
@@ -3,9 +3,9 @@ module Pallets
     attr_reader :workers, :scheduler
 
     def initialize(concurrency: Pallets.configuration.concurrency)
-      backend = Pallets.backend
-      @workers = concurrency.times.map { Worker.new(self, backend) }
-      @scheduler = Scheduler.new(self, backend)
+      @backend = Pallets.backend
+      @workers = concurrency.times.map { Worker.new(self, @backend) }
+      @scheduler = Scheduler.new(self, @backend)
       @lock = Mutex.new
       @needs_to_stop = false
     end
@@ -49,7 +49,7 @@ module Pallets
 
         return if @needs_to_stop
 
-        worker = Worker.new(self)
+        worker = Worker.new(self, @backend)
         @workers << worker
         worker.start
       end

--- a/lib/pallets/manager.rb
+++ b/lib/pallets/manager.rb
@@ -3,8 +3,9 @@ module Pallets
     attr_reader :workers, :scheduler
 
     def initialize(concurrency: Pallets.configuration.concurrency)
-      @workers = concurrency.times.map { Worker.new(self) }
-      @scheduler = Scheduler.new(self)
+      backend = Pallets.backend
+      @workers = concurrency.times.map { Worker.new(self, backend) }
+      @scheduler = Scheduler.new(self, backend)
       @lock = Mutex.new
       @needs_to_stop = false
     end

--- a/lib/pallets/scheduler.rb
+++ b/lib/pallets/scheduler.rb
@@ -1,7 +1,8 @@
 module Pallets
   class Scheduler
-    def initialize(manager)
+    def initialize(manager, backend)
       @manager = manager
+      @backend = backend
       @needs_to_stop = false
       @thread = nil
     end
@@ -35,7 +36,7 @@ module Pallets
       loop do
         break if needs_to_stop?
 
-        backend.reschedule_all(Time.now.to_f)
+        @backend.reschedule_all(Time.now.to_f)
         wait_a_bit
       end
     end
@@ -54,10 +55,6 @@ module Pallets
         break if needs_to_stop?
         sleep 1
       end
-    end
-
-    def backend
-      @backend ||= Pallets.backend
     end
   end
 end

--- a/lib/pallets/worker.rb
+++ b/lib/pallets/worker.rb
@@ -1,7 +1,5 @@
 module Pallets
   class Worker
-    attr_reader :manager
-
     def initialize(manager, backend)
       @manager = manager
       @backend = backend

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe Pallets::Scheduler do
-  subject { Pallets::Scheduler.new(manager) }
+  subject { Pallets::Scheduler.new(manager, backend) }
 
   let(:manager) { instance_spy('Pallets::Manager') }
+  let(:backend) { instance_spy('Pallets::Backends::Base') }
 
   describe '#start' do
     before do
@@ -91,12 +92,9 @@ describe Pallets::Scheduler do
   end
 
   describe '#work' do
-    let(:backend) { instance_spy('Pallets::Backends::Base') }
-
     before do
       allow(Pallets.configuration).to receive(:scheduler_polling_interval).and_return(10)
       allow(subject).to receive(:loop).and_yield
-      allow(subject).to receive(:backend).and_return(backend)
       # Do not *actually* sleep
       allow(subject).to receive(:sleep)
     end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe Pallets::Worker do
-  subject { Pallets::Worker.new(manager) }
+  subject { Pallets::Worker.new(manager, backend) }
 
   let(:manager) { instance_spy('Pallets::Manager') }
+  let(:backend) { instance_spy('Pallets::Backends::Base') }
 
   describe '#start' do
     before do
@@ -85,15 +86,14 @@ describe Pallets::Worker do
   end
 
   describe '#work' do
-    let(:backend) { instance_spy('Pallets::Backends::Base', pick: job) }
     let(:job) { double }
 
     before do
       allow(subject).to receive(:loop).and_yield
-      allow(subject).to receive(:backend).and_return(backend)
       allow(subject).to receive(:process).with(job)
       # Do not *actually* sleep
       allow(subject).to receive(:sleep)
+      allow(backend).to receive(:pick).and_return(job)
     end
 
     it 'tells the backend to pick work' do


### PR DESCRIPTION
The backend was evaluated in each worker, causing multiple instances to live at the same time, which in turn created multiple pools that consequently increased the number of Redis connections.

This should evaluate the backend once, in the manager, and then simply pass it down the line to workers and the scheduler.